### PR TITLE
Change repository URL to HTTPS

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/larrymyers/jasmine-reporters.git"
+    "url": "https://github.com/larrymyers/jasmine-reporters.git"
   },
   "dependencies": {
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
The supplied URL is only valid when accessing the repository as maintainer. This URL seems be put into package-lock.json and prevents a npm install.